### PR TITLE
Updated chart to use '.org' rather than '.net'

### DIFF
--- a/helm/jats-validator/templates/service.yaml
+++ b/helm/jats-validator/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ include "jats-validator.fullname" . }}
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: {{ include "jats-validator.fullname" . }}.elifesciences.net
+    external-dns.alpha.kubernetes.io/hostname: {{ include "jats-validator.fullname" . }}.elifesciences.org
   labels:
     app.kubernetes.io/name: {{ include "jats-validator.name" . }}
     helm.sh/chart: {{ include "jats-validator.chart" . }}


### PR DESCRIPTION
As part of the HTTPS support, have updated the chart to deploy to '.org' rather than '.net'